### PR TITLE
一覧ページの全ページ数のバグ修正

### DIFF
--- a/app/templates/list_contact_emails.html
+++ b/app/templates/list_contact_emails.html
@@ -90,7 +90,7 @@
         <nav aria-label="Page navigation" class="row align-items-center">
             <div class="col-4 text-start">{{ pagination.info }}</div>
             <div class="col-4 text-center">{{ pagination.links }}</div>
-            <div class="col-4 text-end">{{ pagination.page }} / {{ pagination.pages | length }} ページ</div>
+            <div class="col-4 text-end">{{ pagination.page }} / {{ pagination.total_pages }} ページ</div>
         </nav>        
     </div>
 </div>

--- a/app/templates/list_job_emails.html
+++ b/app/templates/list_job_emails.html
@@ -86,7 +86,7 @@
         <nav aria-label="Page navigation" class="row align-items-center">
             <div class="col-4 text-start">{{ pagination.info }}</div>
             <div class="col-4 text-center">{{ pagination.links }}</div>
-            <div class="col-4 text-end">{{ pagination.page }} / {{ pagination.pages | length }} ページ</div>
+            <div class="col-4 text-end">{{ pagination.page }} / {{ pagination.total_pages }} ページ</div>
         </nav>        
     </div>
 </div>


### PR DESCRIPTION
一覧ページの右端「XX / XXページ」に表示される全体のページ数が間違っていたので、正しい数に修正しました。
確認をお願いいたします。
