### PR TITLE
詳細と削除ボタンの幅を修正

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -28,10 +28,6 @@ body {
 }
 
 /* カスタム幅 */
-.max-width-35 {
-    max-width: 35px;
-}
-
 .max-width-40 {
     max-width: 40px;
 }

--- a/app/templates/list_contact_emails.html
+++ b/app/templates/list_contact_emails.html
@@ -63,10 +63,10 @@
         <tbody>
             {% for mail in mails %}
             <tr>
-                <td class="px-1 max-width-35">
+                <td class="px-1 max-width-40">
                     <a href="{{ url_for('main.show_contact_email', id=mail.id) }}" class="btn btn-outline-primary btn-sm p-1">詳細</a>
                 </td>
-                <td class="px-1 max-width-35">
+                <td class="px-1 max-width-40">
                     <!-- 削除ボタン -->
                     <form id="delete-form-{{ mail.id }}" action="{{ url_for('main.delete_contact_email', id=mail.id) }}" method="POST" style="display: none;">
                         {{ form.hidden_tag() }}


### PR DESCRIPTION
一覧画面の「詳細」「削除」ボタンの幅を調整して、できるだけボタンの文字が縦ではなく横向きに表示されるようにしました。
確認をお願いいたします。
