### PR TITLE
一覧表示の文字数を修正

### DIFF
--- a/app/templates/list_contact_emails.html
+++ b/app/templates/list_contact_emails.html
@@ -80,7 +80,7 @@
                 </td>
                 <td class="ps-4">{{mail.received_at}}</td>
                 <td>{{mail.contact_type | contact_type}}</td>
-                <td>{{mail.content | truncate(30, end='...')}}</td>
+                <td>{{mail.content | truncate(30, true, end='...')}}</td>
                 <td>{{mail.email}}</td>
             </tr>
             {% endfor %}

--- a/app/templates/list_contact_emails.html
+++ b/app/templates/list_contact_emails.html
@@ -80,7 +80,7 @@
                 </td>
                 <td class="ps-4">{{mail.received_at}}</td>
                 <td>{{mail.contact_type | contact_type}}</td>
-                <td>{{mail.content | truncate(30, true, end='...')}}</td>
+                <td>{{mail.content | truncate(30, True, end='...')}}</td>
                 <td>{{mail.email}}</td>
             </tr>
             {% endfor %}

--- a/app/templates/list_job_emails.html
+++ b/app/templates/list_job_emails.html
@@ -76,7 +76,7 @@
                     <button id="delete-button-{{ mail.id }}" class="btn btn-outline-danger btn-sm p-1">削除</button>
                 </td>
                 <td class="ps-4">{{mail.received_at}}</td>
-                <td>{{mail.content| truncate(50, true, end='...')}}</td>
+                <td>{{mail.content| truncate(50, True, end='...')}}</td>
                 <td>{{mail.email}}</td>
             </tr>
             {% endfor %}

--- a/app/templates/list_job_emails.html
+++ b/app/templates/list_job_emails.html
@@ -76,7 +76,7 @@
                     <button id="delete-button-{{ mail.id }}" class="btn btn-outline-danger btn-sm p-1">削除</button>
                 </td>
                 <td class="ps-4">{{mail.received_at}}</td>
-                <td>{{mail.content| truncate(50, end='...')}}</td>
+                <td>{{mail.content| truncate(50, true, end='...')}}</td>
                 <td>{{mail.email}}</td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
一覧の文字数が省略される際の表示を修正しました。

一覧表示の文字数を切り詰める際に、jinjaのfilterで調整していましたが、
使用したtruncateフィルターの引数の設定を修正して（第2引数をTrueにして）、
文字数が単語の途中でも最後の文字まで表示されるようにしました。

ご確認をお願いいたします。
