### PR TITLE
検索対象期間（日付）の条件修正

### DIFF
--- a/app/static/js/set_date_placeholder.js
+++ b/app/static/js/set_date_placeholder.js
@@ -10,7 +10,7 @@ const setupDateInput = (id, placeholderText) => {
     };
 
     // 初期設定はtext（プレースホルダー表示）
-    toggleType(false);
+    !dateInput.value && toggleType(false);
 
     // フォーカスされた時またはフォーカスが外れた時に設定
     dateInput.addEventListener('focus', () => toggleType(true));

--- a/app/templates/list_contact_emails.html
+++ b/app/templates/list_contact_emails.html
@@ -78,7 +78,7 @@
                     </form>
                     <button id="delete-button-{{ mail.id }}" class="btn btn-outline-danger btn-sm p-1">削除</button>
                 </td>
-                <td class="ps-4">{{mail.received_at}}</td>
+                <td class="ps-4">{{mail.received_at.strftime('%Y/%m/%d %H:%M:%S')}}</td>
                 <td>{{mail.contact_type | contact_type}}</td>
                 <td>{{mail.content | truncate(30, True, end='...')}}</td>
                 <td>{{mail.email}}</td>

--- a/app/templates/list_job_emails.html
+++ b/app/templates/list_job_emails.html
@@ -75,7 +75,7 @@
                     </form>
                     <button id="delete-button-{{ mail.id }}" class="btn btn-outline-danger btn-sm p-1">削除</button>
                 </td>
-                <td class="ps-4">{{mail.received_at}}</td>
+                <td class="ps-4">{{mail.received_at.strftime('%Y/%m/%d %H:%M:%S')}}</td>
                 <td>{{mail.content| truncate(50, True, end='...')}}</td>
                 <td>{{mail.email}}</td>
             </tr>

--- a/app/templates/show_contact_email.html
+++ b/app/templates/show_contact_email.html
@@ -24,7 +24,7 @@
             <li class="list-group-item"><dt>メールアドレス</dt><dd>{{mail.email}}</dd></li>
             <li class="list-group-item"><dt>性別</dt><dd>{{mail.gender | gender}}</dd></li>
             <li class="list-group-item"><dt>送信元IPアドレス</dt><dd>{{mail.ip}}</dd></li>
-            <li class="list-group-item"><dt>受信日時</dt><dd>{{mail.received_at}}</dd></li>
+            <li class="list-group-item"><dt>受信日時</dt><dd>{{mail.received_at.strftime('%Y/%m/%d %H:%M:%S')}}</dd></li>
         </ul>
     </div>
     <div class="card-footer my-3">

--- a/app/templates/show_job_email.html
+++ b/app/templates/show_job_email.html
@@ -20,7 +20,7 @@
             <li class="list-group-item"><dt>件名</dt><dd>{{mail.subject}}</dd></li>
             <li class="list-group-item"><dt>メールアドレス</dt><dd>{{mail.email}}</dd></li>
             <li class="list-group-item"><dt>本文</dt><dd class="preformatted">{{mail.content}}</dd></li>
-            <li class="list-group-item"><dt>受信日時</dt><dd>{{mail.received_at}}</dd></li>
+            <li class="list-group-item"><dt>受信日時</dt><dd>{{mail.received_at.strftime('%Y/%m/%d %H:%M:%S')}}</dd></li>
         </ul>
     </div>
     <div class="card-footer my-3">

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,10 +1,14 @@
+from datetime import date, datetime
+
 from app.forms import ContactEmailSearchForm, JobEmailSearchForm
 from app.models import ContactEmail, JobEmail
 from app.services import (
     _replace_none_with_empty_string,
+    end_of_day,
     search_contact_emails,
     search_job_emails,
     sort_emails_by_received_at,
+    start_of_day,
     validate_input,
 )
 from tests.mock import MockSearchForm
@@ -58,7 +62,7 @@ def test_search_contact_emails_no_filters(client, init_contact_emails_for_search
 def test_search_contact_emails_with_start_date(client, init_contact_emails_for_search):
     """開始日付のみ指定した場合は、その日付以降のメールを返す"""
     form = ContactEmailSearchForm()
-    form.start_date.data = "2025-02-01"
+    form.start_date.data = datetime(2025, 2, 1)
     form.end_date.data = ""
     form.keyword.data = ""
     form.type.data = ""
@@ -74,7 +78,7 @@ def test_search_contact_emails_with_end_date(client, init_contact_emails_for_sea
     """終了日付のみ指定した場合は、その日付以前のメールを返す"""
     form = ContactEmailSearchForm()
     form.start_date.data = ""
-    form.end_date.data = "2025-01-31"
+    form.end_date.data = datetime(2025, 1, 31)
     form.keyword.data = ""
     form.type.data = ""
 
@@ -118,8 +122,8 @@ def test_search_contact_emails_with_type(client, init_contact_emails_for_search)
 def test_search_contact_emails_with_all_filters(client, init_contact_emails_for_search):
     """全ての条件を指定した場合は、全ての条件に合致するメールを返す"""
     form = ContactEmailSearchForm()
-    form.start_date.data = "2025-01-01"
-    form.end_date.data = "2025-02-01"
+    form.start_date.data = datetime(2025, 1, 1)
+    form.end_date.data = datetime(2025, 2, 1)
     form.keyword.data = "Test content 1"
     form.type.data = 1
 
@@ -147,7 +151,7 @@ def test_search_job_emails_no_filters(client, init_job_emails_for_search):
 def test_search_job_emails_with_start_date(client, init_job_emails_for_search):
     """開始日付のみ指定した場合は、その日付以降のメールを返す"""
     form = JobEmailSearchForm()
-    form.start_date.data = "2025-02-01"
+    form.start_date.data = datetime(2025, 2, 1)
     form.end_date.data = ""
     form.keyword.data = ""
 
@@ -162,7 +166,7 @@ def test_search_job_emails_with_end_date(client, init_job_emails_for_search):
     """終了日付のみ指定した場合は、その日付以前のメールを返す"""
     form = JobEmailSearchForm()
     form.start_date.data = ""
-    form.end_date.data = "2025-01-31"
+    form.end_date.data = datetime(2025, 1, 31)
     form.keyword.data = ""
 
     query = JobEmail.query
@@ -189,8 +193,8 @@ def test_search_job_emails_with_keyword(client, init_job_emails_for_search):
 def test_search_job_emails_with_all_filters(client, init_job_emails_for_search):
     """全ての条件を指定した場合は、全ての条件に合致するメールを返す"""
     form = JobEmailSearchForm()
-    form.start_date.data = "2025-01-01"
-    form.end_date.data = "2025-02-01"
+    form.start_date.data = datetime(2025, 1, 1)
+    form.end_date.data = datetime(2025, 2, 1)
     form.keyword.data = "Test content 1"
 
     query = JobEmail.query
@@ -198,6 +202,20 @@ def test_search_job_emails_with_all_filters(client, init_job_emails_for_search):
     results = query.all()
     assert len(results) == 1
     assert results[0].content == "Test content 1"
+
+
+def test_start_of_day():
+    """開始日の00:00:00を返すテスト"""
+    test_date = date(2025, 2, 3)
+    expected = datetime(2025, 2, 3, 0, 0, 0)
+    assert start_of_day(test_date) == expected
+
+
+def test_end_of_day():
+    """終了日の23:59:59を返すテスト"""
+    test_date = date(2025, 2, 3)
+    expected = datetime(2025, 2, 3, 23, 59, 59, 999999)
+    assert end_of_day(test_date) == expected
 
 
 def test_sort_emails_by_received_at_asc(init_sort_emails):


### PR DESCRIPTION
検索対象期間（日付）の条件を修正しました。

検索時に日付を比較する際に、データベースにある日付には時間が含まれているけれども
検索条件の日付には時間が含まれていなかったため、検索結果がおかしくなる場合がありました。

そのため、開始日付には0時0分0秒を、終了日付には23時59分59秒を設定して検索するようにしました。

また、検索対象期間の表示について、javascriptを使ってテキストと日付を切り替えていた箇所でミスがありました。
日付の再表示の際に値が入っている場合は日付形式で表示しないといけないのに、値が空の時と同様にテキストで表示していました。
そのため表示が一部おかしくなっていたので修正しました。

以上、ご確認のほど、何卒よろしくお願いいたします。


