### PR TITLE
求人関係メール一覧画面の内容を件名に入れ替え

### DIFF
--- a/app/templates/list_job_emails.html
+++ b/app/templates/list_job_emails.html
@@ -53,7 +53,7 @@
                 <th></th>
                 <th></th>
                 <th class="ps-4">{{ toggle_received_at_link("main.list_job_emails", request.args.to_dict()) }}</th>
-                <th>内容</th>
+                <th>件名</th>
                 <th>送信元メールアドレス</th>
             </tr>
         </thead>
@@ -76,7 +76,7 @@
                     <button id="delete-button-{{ mail.id }}" class="btn btn-outline-danger btn-sm p-1">削除</button>
                 </td>
                 <td class="ps-4">{{mail.received_at.strftime('%Y/%m/%d %H:%M:%S')}}</td>
-                <td>{{mail.content| truncate(50, True, end='...')}}</td>
+                <td>{{mail.subject | truncate(50, True, end='...')}}</td>
                 <td>{{mail.email | truncate(24, True, end='...')}}</td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
求人関係メール一覧画面の「内容」列を「件名」列にしました。
ご確認のほど、よろしくお願いいたします。
