### PR TITLE
検索キーワードに特殊文字%_が含まれる場合のエスケープ処理を追加

### DIFF
--- a/app/services.py
+++ b/app/services.py
@@ -41,11 +41,13 @@ def search_contact_emails(query: Query, form: FlaskForm) -> Query:
     if form.end_date.data:
         query = query.filter(ContactEmail.received_at <= end_of_day(form.end_date.data))  # type: ignore
     if form.keyword.data:
+        # ユーザー入力のキーワードに含まれる特殊文字(%, _)をエスケープする
+        keyword = f"%{form.keyword.data.replace('%', '\\%').replace('_', '\\_')}%"
         query = query.filter(
-            ContactEmail.content.like(f"%{form.keyword.data}%")  # type: ignore
-            | ContactEmail.name.like(f"%{form.keyword.data}%")  # type: ignore
-            | ContactEmail.kana.like(f"%{form.keyword.data}%")  # type: ignore
-            | ContactEmail.email.like(f"%{form.keyword.data}%")  # type: ignore
+            ContactEmail.content.like(keyword, escape="\\")  # type: ignore
+            | ContactEmail.name.like(keyword, escape="\\")  # type: ignore
+            | ContactEmail.kana.like(keyword, escape="\\")  # type: ignore
+            | ContactEmail.email.like(keyword, escape="\\")  # type: ignore
         )
     if form.type.data:
         query = query.filter(ContactEmail.contact_type == int(form.type.data))  # type: ignore
@@ -60,10 +62,12 @@ def search_job_emails(query: Query, form: FlaskForm) -> Query:
     if form.end_date.data:
         query = query.filter(JobEmail.received_at <= end_of_day(form.end_date.data))  # type: ignore
     if form.keyword.data:
+        # ユーザー入力のキーワードに含まれる特殊文字(%, _)をエスケープする
+        keyword = f"%{form.keyword.data.replace('%', '\\%').replace('_', '\\_')}%"
         query = query.filter(
-            JobEmail.content.like(f"%{form.keyword.data}%")  # type: ignore
-            | JobEmail.subject.like(f"%{form.keyword.data}%")  # type: ignore
-            | JobEmail.email.like(f"%{form.keyword.data}%")  # type: ignore
+            JobEmail.content.like(keyword, escape="\\")  # type: ignore
+            | JobEmail.subject.like(keyword, escape="\\")  # type: ignore
+            | JobEmail.email.like(keyword, escape="\\")  # type: ignore
         )
 
     return query

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,6 +145,56 @@ def init_contact_emails_for_search(db_session):
 
 
 @pytest.fixture
+def init_contact_emails_for_specialchars_search(db_session):
+    db_session.add_all(
+        [
+            ContactEmail(
+                content="Test content 100%",
+                name="Test name 1",
+                kana="テストイチ",
+                email="test1@example.com",
+                contact_type=1,
+                received_at=datetime(2025, 1, 9, 12, 0, 1),
+                gender=1,
+                ip="192.168.1.1",
+            ),
+            ContactEmail(
+                content="Test content2 (・_・;)",
+                name="Test name 2",
+                kana="テストニ",
+                email="test2@example.com",
+                contact_type=2,
+                received_at=datetime(2025, 2, 9, 12, 0, 2),
+                gender=2,
+                ip="192.168.1.2",
+            ),
+        ]
+    )
+    db_session.commit()
+
+
+@pytest.fixture
+def init_job_emails_for_specialchars_search(db_session):
+    db_session.add_all(
+        [
+            JobEmail(
+                subject="Test subject 1 (・_・)",
+                email="test1@example.com",
+                content="Test content 1",
+                received_at=datetime(2025, 1, 9, 12, 0, 1),
+            ),
+            JobEmail(
+                subject="Test subject 2%",
+                email="test2@example.com",
+                content="Test content 2",
+                received_at=datetime(2025, 2, 9, 12, 0, 2),
+            ),
+        ]
+    )
+    db_session.commit()
+
+
+@pytest.fixture
 def init_job_emails_for_search(db_session):
     db_session.add_all(
         [

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -134,6 +134,35 @@ def test_search_contact_emails_with_all_filters(client, init_contact_emails_for_
     assert results[0].content == "Test content 1"
 
 
+def test_search_contact_emails_with_percentage(client, init_contact_emails_for_specialchars_search):
+    """% が含まれる場合"""
+    form = ContactEmailSearchForm()
+    form.start_date.data = ""
+    form.end_date.data = ""
+    form.keyword.data = "%"
+    form.type.data = ""
+
+    query = ContactEmail.query
+    query = search_contact_emails(query, form)
+    results = query.all()
+    assert len(results) == 1
+    assert results[0].content == "Test content 100%"
+
+
+def test_search_contact_emails_with_underscore(client, init_contact_emails_for_specialchars_search):
+    """_が含まれる場合"""
+    form = ContactEmailSearchForm()
+    form.start_date.data = ""
+    form.end_date.data = ""
+    form.keyword.data = "_"
+    form.type.data = ""
+
+    query = ContactEmail.query
+    query = search_contact_emails(query, form)
+    results = query.all()
+    assert len(results) == 1
+    assert results[0].content == "Test content2 (・_・;)"
+
 # 求人関係メールの検索ロジックのテスト
 def test_search_job_emails_no_filters(client, init_job_emails_for_search):
     """検索条件がない場合は全てのメールを返す"""
@@ -202,6 +231,34 @@ def test_search_job_emails_with_all_filters(client, init_job_emails_for_search):
     results = query.all()
     assert len(results) == 1
     assert results[0].content == "Test content 1"
+
+
+def test_search_job_emails_with_percentage(client, init_job_emails_for_specialchars_search):
+    """% が含まれる場合"""
+    form = JobEmailSearchForm()
+    form.start_date.data = ""
+    form.end_date.data = ""
+    form.keyword.data = "%"
+
+    query = JobEmail.query
+    query = search_job_emails(query, form)
+    results = query.all()
+    assert len(results) == 1
+    assert results[0].subject == "Test subject 2%"
+
+
+def test_search_job_emails_with_underscore(client, init_job_emails_for_specialchars_search):
+    """_が含まれる場合"""
+    form = JobEmailSearchForm()
+    form.start_date.data = ""
+    form.end_date.data = ""
+    form.keyword.data = "_"
+
+    query = JobEmail.query
+    query = search_job_emails(query, form)
+    results = query.all()
+    assert len(results) == 1
+    assert results[0].subject == "Test subject 1 (・_・)"
 
 
 def test_start_of_day():


### PR DESCRIPTION
検索キーワードに特殊文字%_が含まれる場合に、
そのままlikeメソッドで検索するとSQLのLike句で%や_と解釈されてしまうため、
エスケープしてlikeメソッドに渡すよう修正しました。

ご確認をお願いいたします。